### PR TITLE
Track the behaviour's connection state

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,39 @@ directory. Writing a handler is easy:
 
 -export([
          start_link/0,
-         init/1,
-         websocket_handle/2,
-         websocket_info/2
+         init/2,
+         websocket_handle/3,
+         websocket_info/3,
+         websocket_terminate/3
         ]).
 
 start_link() ->
-    websocket_client:start_link("ws://echo.websocket.org:80", ?MODULE, []).
+    crypto:start(),
+    ssl:start(),
+    websocket_client:start_link("wss://echo.websocket.org", ?MODULE, []).
 
-init([]) ->
-    self() ! start,
-    {ok, 1}.
+init([], _ConnState) ->
+    websocket_client:cast(self(), {text, <<"message 1">>}),
+    {ok, 2}.
 
-websocket_handle({text, Msg}, State) ->
+websocket_handle({pong, _}, _ConnState, State) ->
+    {ok, State};
+websocket_handle({text, Msg}, _ConnState, 5) ->
+    io:format("Received msg ~p~n", [Msg]),
+    {close, <<>>, 10};
+websocket_handle({text, Msg}, _ConnState, State) ->
     io:format("Received msg ~p~n", [Msg]),
     timer:sleep(1000),
     BinInt = list_to_binary(integer_to_list(State)),
     {reply, {text, <<"hello, this is message #", BinInt/binary >>}, State + 1}.
 
-websocket_info(start, State) ->
-    {reply, {text, <<"this is message 1">>}, State + 1}.
+websocket_info(start, _ConnState, State) ->
+    {reply, {text, <<"erlang message received">>}, State}.
+
+websocket_terminate({close, Code, Payload}, _ConnState, State) ->
+    io:format("Websocket closed in state ~p wih code ~p and payload ~p~n",
+              [State, Code, Payload]),
+    ok.
 ```
 
 The above code will send messages to the echo server that count up

--- a/examples/sample_ws_handler.erl
+++ b/examples/sample_ws_handler.erl
@@ -4,10 +4,10 @@
 
 -export([
          start_link/0,
-         init/1,
-         websocket_handle/2,
-         websocket_info/2,
-         websocket_terminate/2
+         init/2,
+         websocket_handle/3,
+         websocket_info/3,
+         websocket_terminate/3
         ]).
 
 start_link() ->
@@ -15,25 +15,25 @@ start_link() ->
     ssl:start(),
     websocket_client:start_link("wss://echo.websocket.org", ?MODULE, []).
 
-init([]) ->
+init([], _ConnState) ->
     websocket_client:cast(self(), {text, <<"message 1">>}),
     {ok, 2}.
 
-websocket_handle({pong, _}, State) ->
+websocket_handle({pong, _}, _ConnState, State) ->
     {ok, State};
-websocket_handle({text, Msg}, 5) ->
+websocket_handle({text, Msg}, _ConnState, 5) ->
     io:format("Received msg ~p~n", [Msg]),
     {close, <<>>, 10};
-websocket_handle({text, Msg}, State) ->
+websocket_handle({text, Msg}, _ConnState, State) ->
     io:format("Received msg ~p~n", [Msg]),
     timer:sleep(1000),
     BinInt = list_to_binary(integer_to_list(State)),
     {reply, {text, <<"hello, this is message #", BinInt/binary >>}, State + 1}.
 
-websocket_info(start, State) ->
+websocket_info(start, _ConnState, State) ->
     {reply, {text, <<"erlang message received">>}, State}.
 
-websocket_terminate({close, Code, Payload}, State) ->
+websocket_terminate({close, Code, Payload}, _ConnState, State) ->
     io:format("Websocket closed in state ~p wih code ~p and payload ~p~n",
               [State, Code, Payload]),
     ok.

--- a/examples/ws_ping_example.erl
+++ b/examples/ws_ping_example.erl
@@ -4,10 +4,10 @@
 
 -export([
          start_link/0,
-         init/1,
-         websocket_handle/2,
-         websocket_info/2,
-         websocket_terminate/2
+         init/2,
+         websocket_handle/3,
+         websocket_info/3,
+         websocket_terminate/3
         ]).
 
 start_link() ->
@@ -15,27 +15,34 @@ start_link() ->
     ssl:start(),
     websocket_client:start_link("wss://echo.websocket.org", ?MODULE, []).
 
-init([]) ->
+init([], _ConnState) ->
     websocket_client:cast(self(), {text, <<"message 1">>}),
     %% Execute a ping every 1000 milliseconds
     {ok, 2, 1000}.
 
-websocket_handle({pong, _Msg}, State) ->
+websocket_handle({pong, _Msg}, _ConnState, State) ->
     io:format("Received pong ~n"),
+
+    %% This is how to access info about the connection/request
+    Proto = websocket_req:protocol(_ConnState),
+    io:format("On protocol: ~p~n", [Proto]),
+
     {ok, State};
-websocket_handle({text, Msg}, 5) ->
+websocket_handle({text, Msg}, _ConnState, 5) ->
     io:format("Received msg ~p~n", [Msg]),
     {close, <<>>, 10};
-websocket_handle({text, Msg}, State) ->
+websocket_handle({text, Msg}, _ConnState, State) ->
     io:format("Received msg ~p~n", [Msg]),
     timer:sleep(1000),
     BinInt = list_to_binary(integer_to_list(State)),
-    {reply, {text, <<"hello, this is message #", BinInt/binary >>}, State + 1}.
+    Reply = {text, <<"hello, this is message #", BinInt/binary >>},
+    io:format("Replying: ~p~n", [Reply]),
+    {reply, Reply, State + 1}.
 
-websocket_info(start, State) ->
+websocket_info(start, _ConnState, State) ->
     {reply, {text, <<"erlang message received">>}, State}.
 
-websocket_terminate({close, Code, Payload}, State) ->
+websocket_terminate({close, Code, Payload}, _ConnState, State) ->
     io:format("Websocket closed in state ~p wih code ~p and payload ~p~n",
               [State, Code, Payload]),
     ok.

--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -9,30 +9,6 @@
 
 -export([ws_client_init/6]).
 
--export_type([protocol/0, opcode/0, frame/0]).
-
--type protocol() :: ws | wss.
-
--type opcode() :: 0 | 1 | 2 | 8 | 9 | 10.
-
--type frame() :: close | ping | pong |
-  {text | binary | close | ping | pong, binary()}
-  | {close, 1000..4999, binary()}.
-
--record(state, {
-          protocol :: protocol(),
-          host :: string(),
-          port :: inet:port_number(),
-          path ::  string(),
-          keepalive :: integer(),
-          socket :: inet:socket() | ssl:sslsocket(),
-          transport :: module(),
-          handler :: module(),
-          key :: binary(),
-          remaining :: undefined | integer(),
-          opcode :: opcode()
-         }).
-
 %% @doc Start the websocket client
 -spec start_link(URL :: string(), Handler :: module(), Args :: list()) ->
     {ok, pid()} | {error, term()}.
@@ -46,14 +22,14 @@ start_link(URL, Handler, Args) ->
   end.
 
 %% Send a frame asynchronously
--spec cast(Client :: pid(), Frame :: frame()) ->
+-spec cast(Client :: pid(), Frame :: websocket_req:frame()) ->
     ok.
 cast(Client, Frame) ->
     Client ! {cast, Frame},
     ok.
 
 %% @doc Create socket, execute handshake, and enter loop
--spec ws_client_init(Handler :: module(), Protocol :: protocol(),
+-spec ws_client_init(Handler :: module(), Protocol :: websocket_req:protocol(),
                      Host :: string(), Port :: inet:port_number(), Path :: string(),
                      Args :: list()) ->
     no_return().
@@ -86,36 +62,44 @@ ws_client_init(Handler, Protocol, Host, Port, Path, Args) ->
         exit(normal)
     end,
     proc_lib:init_ack({ok, self()}),
-    State = #state{
-      protocol = Protocol,
-      host = Host,
-      port = Port,
-      path = Path,
-      transport = Transport,
-      handler = Handler,
-      key = generate_ws_key(),
-      socket = Socket
-     },
-    ok = websocket_handshake(State),
+    WSReq = websocket_req:new(
+      Protocol,
+      Host,
+      Port,
+      Path,
+      infinity, %% Keepalive
+      Socket,
+      Transport,
+      Handler,
+      generate_ws_key(),
+      undefined, %% Remaining
+      undefined  %% Opcode
+    ),
+    ok = websocket_handshake(WSReq),
     case Socket of
         {sslsocket, _, _} ->
             ssl:setopts(Socket, [{active, true}]);
         _ ->
             inet:setopts(Socket, [{active, true}])
     end,
-    {ok, HandlerState, KeepAlive} = case Handler:init(Args) of
+    {ok, HandlerState, KeepAlive} = case Handler:init(Args, WSReq) of
                                         {ok, HS} ->
                                             {ok, HS, 45000};
                                         {ok, HS, KA} ->
                                             {ok, HS, KA}
                                     end,
     erlang:send_after(KeepAlive, self(), keepalive),
-    websocket_loop(State#state{keepalive = KeepAlive}, HandlerState, <<>>).
+    websocket_loop(websocket_req:keepalive(KeepAlive, WSReq), HandlerState, <<>>).
 
 %% @doc Send http upgrade request and validate handshake response challenge
--spec websocket_handshake(State :: tuple()) ->
+-spec websocket_handshake(WSReq :: websocket_req:req()) ->
     ok.
-websocket_handshake(State = #state{protocol = Protocol, path = Path, host = Host, key = Key}) ->
+websocket_handshake(WSReq) ->
+    Protocol = websocket_req:protocol(WSReq),
+    Path = websocket_req:path(WSReq),
+    Host = websocket_req:host(WSReq),
+    Key  = websocket_req:key(WSReq),
+
     Handshake = [<<"GET ">>, Path,
                  <<" HTTP/1.1"
                    "\r\nHost: ">>, Host,
@@ -126,8 +110,8 @@ websocket_handshake(State = #state{protocol = Protocol, path = Path, host = Host
                  <<"\r\nSec-WebSocket-Protocol: "
                    "\r\nSec-WebSocket-Version: 13"
                    "\r\n\r\n">>],
-    Transport = State#state.transport,
-    Socket = State#state.socket,
+    Transport = websocket_req:transport(WSReq),
+    Socket =    websocket_req:socket(WSReq),
     Transport:send(Socket, Handshake),
     {ok, HandshakeResponse} = receive_handshake(<<>>, Transport, Socket),
     validate_handshake(HandshakeResponse, Key),
@@ -149,35 +133,38 @@ receive_handshake(Buffer, Transport, Socket) ->
     end.
 
 %% @doc Main loop
--spec websocket_loop(State :: tuple(), HandlerState :: any(),
+-spec websocket_loop(WSReq :: websocket_req:req(), HandlerState :: any(),
                      Buffer :: binary()) ->
     ok.
-websocket_loop(State = #state{handler = Handler, remaining = Remaining,
-                              socket = Socket, transport = Transport},
-               HandlerState, Buffer) ->
+websocket_loop(WSReq, HandlerState, Buffer) ->
+    Handler = websocket_req:handler(WSReq),
+    Remaining = websocket_req:remaining(WSReq),
+    Socket = websocket_req:socket(WSReq),
+    Transport = websocket_req:transport(WSReq),
+
     receive
         keepalive ->
             ok = Transport:send(Socket, encode_frame({ping, <<>>})),
-            erlang:send_after(State#state.keepalive, self(), keepalive),
-            websocket_loop(State, HandlerState, Buffer);
+            erlang:send_after(websocket_req:keepalive(WSReq), self(), keepalive),
+            websocket_loop(WSReq, HandlerState, Buffer);
         {cast, Frame} ->
             ok = Transport:send(Socket, encode_frame(Frame)),
-            websocket_loop(State, HandlerState, Buffer);
+            websocket_loop(WSReq, HandlerState, Buffer);
         {_Closed, Socket} ->
-            Handler:websocket_terminate({close, 0, <<>>}, HandlerState);
+            Handler:websocket_terminate({close, 0, <<>>}, WSReq, HandlerState);
         {_TransportType, Socket, Data} ->
             case Remaining of
                 undefined ->
-                    retrieve_frame(State, HandlerState,
+                    retrieve_frame(WSReq, HandlerState,
                                    << Buffer/binary, Data/binary >>);
                 _ ->
-                    retrieve_frame(State, HandlerState,
-                                   State#state.opcode, Remaining, Data, Buffer)
+                    retrieve_frame(WSReq, HandlerState,
+                                   websocket_req:opcode(WSReq), Remaining, Data, Buffer)
             end;
         Msg ->
-            Handler = State#state.handler,
-            HandlerResponse = Handler:websocket_info(Msg, HandlerState),
-            handle_response(State, HandlerResponse, Buffer)
+            Handler = websocket_req:handler(WSReq),
+            HandlerResponse = Handler:websocket_info(Msg, WSReq, HandlerState),
+            handle_response(WSReq, HandlerResponse, Buffer)
     end,
     ok.
 
@@ -201,59 +188,44 @@ validate_handshake(HandshakeResponse, Key) ->
                              [{capture, [1], binary}]),
     ok.
 
-%% @doc Mapping from opcode to opcode name
--spec websocket_opcode_to_name(opcode()) ->
-    atom().
-websocket_opcode_to_name(1) -> text;
-websocket_opcode_to_name(2) -> binary;
-websocket_opcode_to_name(8) -> close;
-websocket_opcode_to_name(9) -> ping;
-websocket_opcode_to_name(10) -> pong.
-
-%% @doc Mapping from opcode to opcode name
--spec websocket_name_to_opcode(atom()) ->
-    opcode().
-websocket_name_to_opcode(text) -> 1;
-websocket_name_to_opcode(binary) -> 2;
-websocket_name_to_opcode(close) -> 8;
-websocket_name_to_opcode(ping) -> 9;
-websocket_name_to_opcode(pong) -> 10.
-
-
 
 %% @doc Length is less 126 bytes
-retrieve_frame(State, HandlerState,
+retrieve_frame(WSReq, HandlerWSReq,
                << 1:1, 0:3, Opcode:4, 0:1, Len:7, Rest/bits >>)
   when Len < 126 ->
-    retrieve_frame(State, HandlerState, Opcode, Len, Rest, <<>>);
+    retrieve_frame(WSReq, HandlerWSReq, Opcode, Len, Rest, <<>>);
 %% @doc Length is a 2 byte integer
-retrieve_frame(State, HandlerState,
+retrieve_frame(WSReq, HandlerWSReq,
                << 1:1, 0:3, Opcode:4, 0:1, 126:7, Len:16, Rest/bits >>)
   when Len > 125, Opcode < 8 ->
-    retrieve_frame(State, HandlerState, Opcode, Len, Rest, <<>>);
+    retrieve_frame(WSReq, HandlerWSReq, Opcode, Len, Rest, <<>>);
 %% @doc Length is a 64 bit integer
-retrieve_frame(State, HandlerState,
+retrieve_frame(WSReq, HandlerWSReq,
                << 1:1, 0:3, Opcode:4, 0:1, 127:7, 0:1, Len:63, Rest/bits >>)
   when Len > 16#ffff, Opcode < 8 ->
-    retrieve_frame(State, HandlerState, Opcode, Len, Rest, <<>>);
+    retrieve_frame(WSReq, HandlerWSReq, Opcode, Len, Rest, <<>>);
 %% @doc Need more data to read length properly
-retrieve_frame(State, HandlerState, Data) ->
-    websocket_loop(State, HandlerState, Data).
+retrieve_frame(WSReq, HandlerWSReq, Data) ->
+    websocket_loop(WSReq, HandlerWSReq, Data).
 
 %% @doc Length known and still missing data
-retrieve_frame(State, HandlerState, Opcode, Len, Data, Buffer)
+retrieve_frame(WSReq0, HandlerWSReq, Opcode, Len, Data, Buffer)
   when byte_size(Data) < Len ->
     Remaining = Len - byte_size(Data),
-    websocket_loop(State#state{remaining = Remaining, opcode = Opcode},
-                   HandlerState, << Buffer/bits, Data/bits >>);
+
+    WSReq1 = websocket_req:remaining(Remaining, WSReq0),
+    WSReq  = websocket_req:opcode(Opcode, WSReq1),
+    websocket_loop(WSReq, HandlerWSReq, << Buffer/bits, Data/bits >>);
 %% @doc Length known and remaining data is appended to the buffer
-retrieve_frame(State = #state{
-                 handler = Handler, transport = Transport, socket = Socket
-                },
-               HandlerState, Opcode, Len, Data, Buffer) ->
+retrieve_frame(WSReq, HandlerState, Opcode, Len, Data, Buffer) ->
+
+ Handler = websocket_req:handler(WSReq),
+ Transport = websocket_req:transport(WSReq),
+ Socket = websocket_req:socket(WSReq),
+
     << Payload:Len/binary, Rest/bits >> = Data,
     FullPayload = << Buffer/binary, Payload/binary >>,
-    OpcodeName = websocket_opcode_to_name(Opcode),
+    OpcodeName = websocket_req:opcode_to_name(Opcode),
     case OpcodeName of
         ping ->
             %% If a ping is received, send a pong  automatically
@@ -266,35 +238,43 @@ retrieve_frame(State = #state{
             << CodeBin:2/binary, ClosePayload/binary >> = FullPayload,
             Code = binary:decode_unsigned(CodeBin),
             Handler:websocket_terminate({close, Code, ClosePayload},
-                                        HandlerState);
+                                        WSReq, HandlerState);
         close ->
-            Handler:websocket_terminate({close, 0, <<>>}, HandlerState);
+            Handler:websocket_terminate({close, 0, <<>>}, 
+                                        WSReq, HandlerState);
         _ ->
             HandlerResponse = Handler:websocket_handle(
                                 {OpcodeName, FullPayload},
-                                HandlerState),
-            handle_response(State#state{remaining = undefined},
+                                WSReq, HandlerState),
+            handle_response(websocket_req:remaining(undefined, WSReq),
                             HandlerResponse, Rest)
     end.
 
 %% @doc Handles return values from the callback module
-handle_response(State = #state{socket = Socket, transport = Transport},
-                {reply, Frame, HandlerState}, Buffer) ->
+handle_response(WSReq, {reply, Frame, HandlerState}, Buffer) ->
+
+    Socket = websocket_req:socket(WSReq),
+    Transport = websocket_req:transport(WSReq),
+
     ok = Transport:send(Socket, encode_frame(Frame)),
-    retrieve_frame(State, HandlerState, Buffer);
-handle_response(State = #state{socket = Socket, transport = Transport},
-               {close, Payload, HandlerState}, Buffer) ->
+    retrieve_frame(WSReq, HandlerState, Buffer);
+
+handle_response(WSReq, {close, Payload, HandlerState}, Buffer) ->
+    Socket = websocket_req:socket(WSReq),
+    Transport = websocket_req:transport(WSReq),
+
     ok = Transport:send(Socket, encode_frame({close, Payload})),
-    retrieve_frame(State, HandlerState, Buffer);
-handle_response(State, {ok, HandlerState}, Buffer) ->
-    retrieve_frame(State, HandlerState, Buffer).
+    retrieve_frame(WSReq, HandlerState, Buffer);
+
+handle_response(WSReq, {ok, HandlerState}, Buffer) ->
+    retrieve_frame(WSReq, HandlerState, Buffer).
 
 %% @doc Encodes the data with a header (including a masking key) and
 %% masks the data
--spec encode_frame(frame()) ->
+-spec encode_frame(websocket_req:frame()) ->
     binary().
 encode_frame({Type, Payload}) ->
-    Opcode = websocket_name_to_opcode(Type),
+    Opcode = websocket_req:name_to_opcode(Type),
     Len = iolist_size(Payload),
     BinLen = payload_length_to_binary(Len),
     MaskingKeyBin = crypto:rand_bytes(4),

--- a/src/websocket_client_handler.erl
+++ b/src/websocket_client_handler.erl
@@ -1,22 +1,22 @@
 -module(websocket_client_handler).
 
--type state() :: any().
+-type state() :: any().        %% Implementation state - controlled by implementation.
 -type keepalive() :: integer().
 
 %% @doc spe
--callback init(list()) ->
+-callback init(list(), websocket_req:req()) ->
     {ok, state()}
         | {ok, state(), keepalive()}.
 
--callback websocket_handle({text | binary | ping | pong, binary()}, State :: state()) ->
-    {ok, State :: state()}
-        | {reply, websocket_client:frame(), State :: state()}
-        | {close, binary(), State :: state()}.
+-callback websocket_handle({text | binary | ping | pong, binary()}, websocket_req:req(), state()) ->
+    {ok, state()}
+        | {reply, websocket_client:frame(), state()}
+        | {close, binary(), state()}.
 
--callback websocket_info(any(), State :: state()) ->
-    {ok, State :: state()}
-        | {reply, websocket_client:frame(), State :: state()}
-        | {close, binary(), State :: state()}.
+-callback websocket_info(any(), websocket_req:req(), state()) ->
+    {ok, state()}
+        | {reply, websocket_client:frame(), state()}
+        | {close, binary(),  state()}.
 
--callback websocket_terminate({close, integer(), binary()}, _State :: state()) ->
+-callback websocket_terminate({close, integer(), binary()},  websocket_req:req(), state()) ->
     ok.

--- a/src/websocket_req.erl
+++ b/src/websocket_req.erl
@@ -1,0 +1,178 @@
+%% -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+%% Accessor module for the #websocket_req{} record.
+%%
+%% -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+-module(websocket_req).
+
+-record(websocket_req, {
+          protocol  :: protocol(),
+          host      :: string(),
+          port      :: inet:port_number(),
+          path      :: string(),
+          keepalive :: inifinity | integer(),
+          socket    :: inet:socket() | ssl:sslsocket(),
+          transport :: module(),
+          handler   :: module(),
+          key       :: binary(),
+          remaining :: undefined | integer(),
+          opcode    :: undefined | opcode()
+         }).
+
+-opaque req() :: #websocket_req{}.
+-export_type([req/0]).
+
+-type protocol() :: ws | wss.
+
+-type frame() :: close | ping | pong |
+  {text | binary | close | ping | pong, binary()}
+  | {close, 1000..4999, binary()}.
+
+-type opcode() :: 0 | 1 | 2 | 8 | 9 | 10.
+-export_type([protocol/0, opcode/0, frame/0]).
+
+
+
+-export([new/11,
+         protocol/2,   protocol/1,
+         host/2,       host/1,
+         port/2,       port/1,
+         path/2,       path/1,
+         keepalive/2,  keepalive/1,
+         socket/2,     socket/1,
+         transport/2,  transport/1,
+         handler/2,    handler/1,
+         key/2,        key/1,
+         remaining/2,  remaining/1,
+         opcode/2,     opcode/1
+        ]).
+
+-export([
+    opcode_to_name/1,
+    name_to_opcode/1
+    ]).
+
+-spec new(protocol(), string(), inet:port_number(), string(), integer(), inet:socket() | ssl:sslsocket(), module(), module(), binary(), undefined | integer(), opcode()) -> req().
+new(Protocol, Host, Port,
+    Path, Keepalive, Socket,
+    Transport, Handler, Key, Remaining, Opcode) ->
+    #websocket_req{
+        protocol  = Protocol,
+        host      = Host,
+        port      = Port,
+        path      = Path,
+        keepalive = Keepalive,
+        socket    = Socket,
+        transport = Transport,
+        handler   = Handler,
+        key       = Key,
+        remaining = Remaining,
+        opcode    = Opcode   
+    }.
+
+
+%% @doc Mapping from opcode to opcode name
+-spec opcode_to_name(opcode()) ->
+    atom().
+opcode_to_name(1) -> text;
+opcode_to_name(2) -> binary;
+opcode_to_name(8) -> close;
+opcode_to_name(9) -> ping;
+opcode_to_name(10) -> pong.
+
+%% @doc Mapping from opcode to opcode name
+-spec name_to_opcode(atom()) ->
+    opcode().
+name_to_opcode(text) -> 1;
+name_to_opcode(binary) -> 2;
+name_to_opcode(close) -> 8;
+name_to_opcode(ping) -> 9;
+name_to_opcode(pong) -> 10.
+
+
+-spec protocol(req()) -> protocol().
+protocol(#websocket_req{protocol = P}) -> P.
+
+-spec protocol(protocol(), req()) -> req().
+protocol(P, Req) ->
+	Req#websocket_req{protocol = P}.
+
+
+-spec host(req()) -> string().
+host(#websocket_req{host = H}) -> H.
+
+-spec host(string(), req()) -> req().
+host(H, Req) ->
+	Req#websocket_req{host = H}.
+
+
+-spec port(req()) -> inet:port_number().
+port(#websocket_req{port = P}) -> P.
+
+-spec port(inet:port_number(), req()) -> req().
+port(P, Req) ->
+	Req#websocket_req{port = P}.
+
+
+-spec path(req()) -> string().
+path(#websocket_req{path = P}) -> P.
+
+-spec path(string(), req()) -> req().
+path(P, Req) ->
+	Req#websocket_req{path = P}.
+
+
+-spec keepalive(req()) -> integer().
+keepalive(#websocket_req{keepalive = K}) -> K.
+
+-spec keepalive(integer(), req()) -> req().
+keepalive(K, Req) ->
+	Req#websocket_req{keepalive = K}.
+
+
+-spec socket(req()) -> inet:socket() | ssl:sslsocket().
+socket(#websocket_req{socket = S}) -> S.
+
+-spec socket(inet:socket() | ssl:sslsocket(), req()) -> req().
+socket(S, Req) ->
+	Req#websocket_req{socket = S}.
+
+
+-spec transport(req()) -> module().
+transport(#websocket_req{transport = T}) -> T.
+
+-spec transport(module(), req()) -> req().
+transport(T, Req) ->
+	Req#websocket_req{transport = T}.
+
+
+-spec handler(req()) -> module().
+handler(#websocket_req{handler = H}) -> H.
+
+-spec handler(module(), req()) -> req().
+handler(H, Req) ->
+	Req#websocket_req{handler = H}.
+
+
+-spec key(req()) -> binary().
+key(#websocket_req{key = K}) -> K.
+
+-spec key(binary(), req()) -> req().
+key(K, Req) ->
+	Req#websocket_req{key = K}.
+
+
+-spec remaining(req()) -> undefined | integer().
+remaining(#websocket_req{remaining = R}) -> R.
+
+-spec remaining(undefined | integer(), req()) -> req().
+remaining(R, Req) ->
+	Req#websocket_req{remaining = R}.
+
+
+-spec opcode(req()) -> websocket_client:opcode().
+opcode(#websocket_req{opcode = O}) -> O.
+
+-spec opcode(websocket_client:opcode(), req()) -> req().
+opcode(O, Req) ->
+	Req#websocket_req{opcode = O}.
+


### PR DESCRIPTION
I realise this completely changes the API of this, but I'm proposing it as-is.

We want to be able to, from within the handler, get at the information held about the request/connection. As a result, I've added in the appropriate changes to the API and updated the provided examples to include a trivial example usage.
