### PR TITLE
removed unused websocket protocol header

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -106,7 +106,7 @@ websocket_handshake(WSReq) ->
                    "\r\nConnection: Upgrade"
                    "\r\nSec-WebSocket-Key: ">>, Key,
                  <<"\r\nOrigin: ">>, atom_to_binary(Protocol, utf8), <<"://">>, Host,
-                 <<"\r\nSec-WebSocket-Protocol: "
+                 <<%"\r\nSec-WebSocket-Protocol: "
                    "\r\nSec-WebSocket-Version: 13"
                    "\r\n\r\n">>],
     Transport = websocket_req:transport(WSReq),


### PR DESCRIPTION
Having this header present without a value causes an error during decoding in cowboy, since it's not settable there is little sense in keeping it around.

I have just commented the line it is easyer in the future to pass a option setting it.
