### PR TITLE
Fixed bug with handling multiple ws messages packed into one tcp frame.

### DIFF
--- a/src/websocket_client.app.src
+++ b/src/websocket_client.app.src
@@ -1,7 +1,7 @@
 {application, websocket_client,
  [
   {description, "Erlang websocket client"},
-  {vsn, "0.5.3"},
+  {vsn, "0.5.4"},
   {registered, []},
   {applications, [
                   ssl,

--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -100,8 +100,7 @@ ws_client_init(Handler, Protocol, Host, Port, Path, Args) ->
     websocket_loop(websocket_req:set([{keepalive,KeepAlive},{keepalive_timer,KATimer}], WSReq), HandlerState, <<>>).
 
 %% @doc Send http upgrade request and validate handshake response challenge
--spec websocket_handshake(WSReq :: websocket_req:req()) ->
-                                 ok.
+-spec websocket_handshake(WSReq :: websocket_req:req()) -> {ok, binary()}.
 websocket_handshake(WSReq) ->
     [Protocol, Path, Host, Key, Transport, Socket] =
         websocket_req:get([protocol, path, host, key, transport, socket], WSReq),
@@ -220,8 +219,7 @@ generate_ws_key() ->
     base64:encode(crypto:rand_bytes(16)).
 
 %% @doc Validate handshake response challenge
--spec validate_handshake(HandshakeResponse :: binary(), Key :: binary()) ->
-                                ok.
+-spec validate_handshake(HandshakeResponse :: binary(), Key :: binary()) -> {ok, binary()}.
 validate_handshake(HandshakeResponse, Key) ->
     Challenge = base64:encode(
                   crypto:sha(<< Key/binary, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" >>)),

--- a/src/websocket_req.erl
+++ b/src/websocket_req.erl
@@ -2,21 +2,21 @@
 -module(websocket_req).
 
 -record(websocket_req, {
-          protocol :: protocol(),
-          host :: string(),
-          port :: inet:port_number(),
-          path :: string(),
-          keepalive = infinity :: integer(),
-          keepalive_timer = undefined :: reference(),
-          socket :: inet:socket() | ssl:sslsocket(),
-          transport :: module(),
-          handler :: module(),
-          key :: binary(),
-          remaining = undefined :: integer(),
-          fin = undefined :: fin(),
-          opcode = undefined :: opcode(),
-          continuation = undefined :: binary(),
-          continuation_opcode = undefined :: opcode()
+          protocol                        :: protocol(),
+          host                            :: string(),
+          port                            :: inet:port_number(),
+          path                            :: string(),
+          keepalive = infinity            :: infinity | integer(),
+          keepalive_timer = undefined     :: undefined | reference(),
+          socket                          :: inet:socket() | ssl:sslsocket(),
+          transport                       :: module(),
+          handler                         :: module(),
+          key                             :: binary(),
+          remaining = undefined           :: undefined | integer(),
+          fin = undefined                 :: undefined | fin(),
+          opcode = undefined              :: undefined | opcode(),
+          continuation = undefined        :: undefined | binary(),
+          continuation_opcode = undefined :: undefined | opcode()
          }).
 
 -opaque req() :: #websocket_req{}.


### PR DESCRIPTION
Here is complete fix to following situations: 
- Buffer contains parsed part of message and control should go back to loop to read more data. (#21)
- Two (or more?) ws messages were packed into one tcp frame, so we need to parse (retrieve_frame) buffer again after message was handled.
- Readed data contains final part of one message and first part of another message, then after handling first message remain is set back to undefined (https://github.com/jeremyong/websocket_client/blob/master/src/websocket_client.erl#L344 and https://github.com/jeremyong/websocket_client/blob/master/src/websocket_client.erl#L362), so part of next message will be parsed correctly before going back to loop.
