### PR TITLE
Add travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: erlang
+otp_release:
+  - R16B03
+  - R16B02
+  - R16B01
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 .PHONY: all clean
 
 all:


### PR DESCRIPTION
I had to add the shell used on Makefile. `pushd` and `popd` are not defined for `sh`.

This way we may know when the tests break. Also it's clear that the tests are broken.

You would just need to log on Travis-CI and enable the repository to be built and tested: http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in

Is it something desirable?
