### PR TITLE
Remove redundant assigning of variables

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -112,8 +112,6 @@ websocket_handshake(WSReq) ->
                  "Sec-WebSocket-Key: ", Key, "\r\n"
                  "Upgrade: websocket\r\n"
                  "\r\n"],
-    Transport = websocket_req:transport(WSReq),
-    Socket =    websocket_req:socket(WSReq),
     Transport:send(Socket, Handshake),
     {ok, HandshakeResponse} = receive_handshake(<<>>, Transport, Socket),
     {ok, Buffer} = validate_handshake(HandshakeResponse, Key),


### PR DESCRIPTION
While reading the code, I found out these variables that were already defined on this scope.

Line 105-106:

``` erlang
[Protocol, Path, Host, Key, Transport, Socket] =
          websocket_req:get([protocol, path, host, key, transport, socket], WSReq),
```
