### PR TITLE
Catch handshake error

### DIFF
--- a/ct/wc_SUITE.erl
+++ b/ct/wc_SUITE.erl
@@ -12,7 +12,8 @@
          test_text_frames/1,
          test_binary_frames/1,
          test_control_frames/1,
-         test_quick_response/1
+         test_quick_response/1,
+         test_bad_request/1
         ]).
 
 all() ->
@@ -103,6 +104,12 @@ test_quick_response(_) ->
     {ok, Pid2} = ws_client:start_link("ws://localhost:8080/hello/?q=Hello%0D%0A%0D%0AWorld%0D%0A%0D%0A!"),
     {text, <<"Hello\r\n\r\nWorld\r\n\r\n!">>} = ws_client:recv(Pid2, 100),
     ws_client:stop(Pid2),
+    ok.
+
+test_bad_request(_) ->
+    %% Connect to the server and wait for a error
+    {error, {400, <<"Bad Request">>}} =  ws_client:start_link("ws://localhost:8080/hello/?code=400"),
+    {error, {403, <<"Forbidden">>}} =  ws_client:start_link("ws://localhost:8080/hello/?code=403"),
     ok.
 
 short_msg() ->


### PR DESCRIPTION
- Fix application start up on test suite;
- Catch handshake error and raise `{Status, Message}`;
- Add test for error before switching protocol.

Can you give me some feedback here? I moved the `init_ack(ok, self())` after successful handshake. Is it correct?

This should close #28
