### PR TITLE
Do not send 'Origin' header in handshake

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -122,12 +122,11 @@ ws_client_init(Handler, Protocol, Host, Port, Path, Args, Opts) ->
 %% @doc Send http upgrade request and validate handshake response challenge
 -spec websocket_handshake(WSReq :: websocket_req:req(), [{string(), string()}]) -> {ok, binary()} | {error, term()}.
 websocket_handshake(WSReq, ExtraHeaders) ->
-    [Protocol, Path, Host, Key, Transport, Socket] =
-        websocket_req:get([protocol, path, host, key, transport, socket], WSReq),
+    [Path, Host, Key, Transport, Socket] =
+        websocket_req:get([path, host, key, transport, socket], WSReq),
     Handshake = ["GET ", Path, " HTTP/1.1\r\n"
                  "Host: ", Host, "\r\n"
                  "Connection: Upgrade\r\n"
-                 "Origin: ", atom_to_binary(Protocol, utf8), "://", Host, "\r\n"
                  "Sec-WebSocket-Version: 13\r\n"
                  "Sec-WebSocket-Key: ", Key, "\r\n"
                  "Upgrade: websocket\r\n",


### PR DESCRIPTION
This is a header only intended to support for Web Origin security in
browsers. Other clients are not required to include this header, and the
current case complicates servers since it receiving 'ws://' or 'ws://'
in the 'Origin' header is highly unusual.

RFC 6455, Section 4.1, Client Requirements:

> Additionally, if the client is a web browser, it supplies /origin/.

RFC 6455, Section 4.2.1, Reading the Client's Opening Handshake:

> Optionally, an |Origin| header field.  This header field is sent by
> all browser clients.  A connection attempt lacking this header field
> SHOULD NOT be interpreted as coming from a browser client.
