### PR TITLE
More accurate type spec for websocket_terminate, other minor cleanup

### DIFF
--- a/src/websocket_client_handler.erl
+++ b/src/websocket_client_handler.erl
@@ -2,7 +2,35 @@
 
 -type state() :: any().
 -type keepalive() :: integer().
--type close_type() :: normal | error | remote.
+
+-type close_reason() ::
+    % Either the local end was closed via a `{closed, Reason, State}` tuple
+    % returned from websocket_handle/3 or websocket_info/3, or the remote end
+    % was closed during graceful teardown of the connection via a close frame
+    % (see https://tools.ietf.org/html/rfc6455#section-5.5.1).
+    {normal, binary()} |
+    % The transport failed to send (see http://erlang.org/doc/man/gen_tcp.html#send-2
+    % or http://erlang.org/doc/man/ssl.html#send-2)
+    {error, term()} |
+    % The remote end was closed due to a protocol error
+    % (see https://tools.ietf.org/html/rfc6455#section-7.4.1, status code 1002).
+    {error, badframe, binary()} |
+    % The remote end was closed due to an encoding error
+    % (see https://tools.ietf.org/html/rfc6455#section-7.4.1, status code 1007).
+    {error, badencoding, binary()} |
+    % The remote end was closed unexpectedly
+    % (see https://tools.ietf.org/html/rfc6455#section-7.4.1, status code 1011).
+    {error, handler, binary()} |
+    % The remote host closed the socket.
+    {remote, closed} |
+    % The remote end was closed for some other reason
+    % (see https://tools.ietf.org/html/rfc6455#section-7.4.1).
+    {remote, integer(), binary()} |
+    % The remote host closed the socket.
+    % TODO: How is this different than `{remote, closed}`?
+    {remote, binary()} |
+    % The handler terminated unexpectedly in websocket_handle/3 or websocket_info/3.
+    term().
 
 -callback init(list(), websocket_req:req()) ->
     {ok, state()}
@@ -18,6 +46,4 @@
         | {reply, websocket_req:frame(), state()}
         | {close, binary(),  state()}.
 
--callback websocket_terminate({close_type(), term()} | {close_type(), integer(), binary()},
-                              websocket_req:req(), state()) ->
-    ok.
+-callback websocket_terminate(close_reason(), websocket_req:req(), state()) -> ok.

--- a/src/websocket_req.erl
+++ b/src/websocket_req.erl
@@ -40,6 +40,7 @@
          port/2, port/1,
          path/2, path/1,
          keepalive/2, keepalive/1,
+         keepalive_timer/2, keepalive_timer/1,
          socket/2, socket/1,
          transport/2, transport/1,
          handler/2, handler/1,
@@ -132,6 +133,14 @@ keepalive(#websocket_req{keepalive = K}) -> K.
 -spec keepalive(integer(), req()) -> req().
 keepalive(K, Req) ->
     Req#websocket_req{keepalive = K}.
+
+
+-spec keepalive_timer(req()) -> undefined | reference().
+keepalive_timer(#websocket_req{keepalive_timer = K}) -> K.
+
+-spec keepalive_timer(reference(), req()) -> req().
+keepalive_timer(K, Req) ->
+    Req#websocket_req{keepalive_timer = K}.
 
 
 -spec socket(req()) -> inet:socket() | ssl:sslsocket().


### PR DESCRIPTION
Right now the typespec for websocket_terminate is a lie. With this patch, I got closer to the truth, but I still have an unfortunate "term()" clause (due to any caught exceptions from websocket_handle or websocket_info just being passed verbatim to websocket_close). I'd like to wrap such exceptions with some kind of atom, but I'm not sure how much you're trying to preserve backwards compatibility.

Also, the type can/should probably be consolidated. It has way, way too many shapes, currently.